### PR TITLE
Adding missing types + moving babel-register into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "adm-zip": "0.4.7",
     "archiver": "^1.3.0",
-    "babel-register": "^6.24.1",
     "chalk": "1.1.3",
     "child-process-promise": "2.2.0",
     "clui": "^0.3.1",
@@ -29,6 +28,7 @@
     "node": ">=4.0"
   },
   "devDependencies": {
+    "babel-register": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",

--- a/src/lint-config.js
+++ b/src/lint-config.js
@@ -7,7 +7,7 @@ module.exports = function(configDir, log) {
     return new Promise((resolve, reject) => {
         const config     = getClayConfig(configDir);
         var   errors     = []
-            , validTypes = ['db', 'text', 'url', 'date', 'address', 'select', 'image', 'file', 'json', 'autocomplete'];
+            , validTypes = ['db', 'boolean', 'singleSelect', 'multipleSelect', 'text', 'url', 'date', 'address', 'select', 'image', 'file', 'json', 'autocomplete'];
 
         if(!config.serviceName || config.serviceName.length < 3) {
             errors.push({


### PR DESCRIPTION
Added the following types for the clay-config file:
- singleSelect
- multipleSelect
- boolean

And moved `babel-register` module to `devDependencies`