### PR TITLE
update readme to note deprecation of template option

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,11 @@ $ clay info
 $ clay login
 ```
 
-## Create an Alexa Skill
+## Create an Alexa Skill 
+[This option has been deprecated.](https://github.com/clay-run/clay-cli/issues/8)  
 For a complete walk through check out [this blog
 post](https://medium.com/@nicolaerusan/code-your-first-alexa-skill-in-30-ish-seconds-using-clay-ready-go-8293ee1761ac)
+
 
 
 ```


### PR DESCRIPTION
This is tiny, but it seems the least we can do for anyone coming along initially confused about the out of date documentation regarding the deprecated template option. Please let me know if there is a documentation resource I am lacking. I would love to check it out. Thanks.